### PR TITLE
Implement mv.fade_in, mv.fade_out, and mv.fade_in_out

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ layer_item.add_effect(mv.effect.GaussianBlur(radius=10.0))
 
 Of course, movis also supports simple video processing such as video merging and trimming.
 
+#### concat
+
 ```python
 intro = mv.layer.Video('intro.mp4')
 title = mv.layer.Video('title.mp4')
@@ -108,6 +110,8 @@ scene = mv.concatenate([intro, title, chapter1, ...])
 scene.write_video('output.mp4')
 ```
 
+#### cutout
+
 ```python
 raw_video = mv.layer.Video('video.mp4')
 # select 0.0-1.0 secs and 2.0-3.0 secs, and concatenate them
@@ -115,10 +119,21 @@ scene = mv.trim(layer, start_times=[0.0, 2.0], end_times=[1.0, 3.0])
 scene.write_video('output.mp4')
 ```
 
+#### cropping
+
 ```python
 layer = mv.layer.Image("image.png", duration=1.0)
 # crop from x, y = (10, 20) with size w, h = (100, 200)
 layer = mv.crop(layer, (10, 20, 100, 200))
+```
+
+#### fade-in / out
+
+```python
+layer = mv.layer.Video('video.mp4')
+video1 = mv.fade_in(layer, 1.0)  # fade-in for 1.0 secs
+video2 = mv.fade_out(layer, 1.0)  # fade-out for 1.0 secs
+video3 = mv.fade_in_out(layer, 1.0, 2.0)  # fade-in for 1.0 secs and fade-out for 2.0 secs
 ```
 
 ### Implementation of custom layers, effects, and animations

--- a/docs/reference/ops.rst
+++ b/docs/reference/ops.rst
@@ -12,6 +12,9 @@ The :mod:`~movis.ops` module contains a set of functions for video editing that 
    movis.ops.concatenate
    movis.ops.crop
    movis.ops.insert
+   movis.ops.fade_in
+   movis.ops.fade_out
+   movis.ops.fade_in_out
    movis.ops.repeat
    movis.ops.switch
    movis.ops.tile

--- a/movis/__init__.py
+++ b/movis/__init__.py
@@ -7,7 +7,7 @@ from .enum import (AttributeType, BlendingMode, Direction, Easing,  # noqa
 from .imgproc import alpha_composite  # noqa
 from .layer.protocol import AUDIO_SAMPLING_RATE  # noqa
 from .motion import Motion  # noqa
-from .ops import concatenate, crop, insert, repeat, switch, tile, trim  # noqa
+from .ops import concatenate, crop, fade_in, fade_out, fade_in_out, insert, repeat, switch, tile, trim  # noqa
 from .subtitle import (ASSStyleType, rgb_to_ass_color, write_ass_file,  # noqa
                        write_srt_file)
 from .transform import Transform  # noqa

--- a/movis/ops.py
+++ b/movis/ops.py
@@ -301,33 +301,33 @@ def insert(
 
 
 def fade_in(
-    layer: BasicLayer, fade_in: float = 0.0, size: tuple[int, int] | None = None
+    layer: BasicLayer, duration: float = 0.0, size: tuple[int, int] | None = None
 ) -> Composition:
     """Fade in a layer.
 
     Args:
         layer:
             Layer to fade in.
-        fade_in:
+        duration:
             Duration of the fade-in effect.
         size:
             Size of the composition. If ``None``, the size of the layer is estimated."""
-    return fade_in_out(layer, fade_in=fade_in, fade_out=0.0, size=size)
+    return fade_in_out(layer, fade_in=duration, fade_out=0.0, size=size)
 
 
 def fade_out(
-    layer: BasicLayer, fade_out: float = 0.0, size: tuple[int, int] | None = None
+    layer: BasicLayer, duration: float = 0.0, size: tuple[int, int] | None = None
 ) -> Composition:
     """Fade out a layer.
 
     Args:
         layer:
             Layer to fade out.
-        fade_out:
+        duration:
             Duration of the fade-out effect.
         size:
             Size of the composition. If ``None``, the size of the layer is estimated."""
-    return fade_in_out(layer, fade_in=0.0, fade_out=fade_out, size=size)
+    return fade_in_out(layer, fade_in=0.0, fade_out=duration, size=size)
 
 
 def fade_in_out(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -139,3 +139,30 @@ def test_insert():
     assert np.all(scene(2.0)[0, 0, :] == np.array([2, 2, 2, 2]))
     assert np.all(scene(3.0)[0, 0, :] == np.array([3, 3, 3, 3]))
     assert np.all(scene(6.0 - 1e-5)[0, 0, :] == np.array([3, 3, 3, 3]))
+
+
+def test_fade_in():
+    img = mv.layer.Image.from_color(size=(10, 10), color='white', duration=4.0)
+    scene = mv.fade_in(img, fade_in=1.0)
+
+    assert np.all(scene(0.0)[0, 0, :] == np.array([0, 0, 0, 0]))
+    assert np.all(scene(1.0)[0, 0, :] == np.array([255, 255, 255, 255]))
+
+
+def test_fade_out():
+    img = mv.layer.Image.from_color(size=(10, 10), color='white', duration=4.0)
+    scene = mv.fade_out(img, fade_out=1.0)
+
+    assert np.all(scene(0.0)[0, 0, :] == np.array([255, 255, 255, 255]))
+    assert np.all(scene(3.0)[0, 0, :] == np.array([255, 255, 255, 255]))
+    assert np.all(scene(4.0 - 1e-5)[0, 0, :] == np.array([0, 0, 0, 0]))
+
+
+def test_fade_in_out():
+    img = mv.layer.Image.from_color(size=(10, 10), color='white', duration=4.0)
+    scene = mv.fade_in_out(img, fade_in=1.0, fade_out=2.0)
+
+    assert np.all(scene(0.0)[0, 0, :] == np.array([0, 0, 0, 0]))
+    assert np.all(scene(1.0)[0, 0, :] == np.array([255, 255, 255, 255]))
+    assert np.all(scene(2.0)[0, 0, :] == np.array([255, 255, 255, 255]))
+    assert np.all(scene(4.0 - 1e-5)[0, 0, :] == np.array([0, 0, 0, 0]))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -143,7 +143,7 @@ def test_insert():
 
 def test_fade_in():
     img = mv.layer.Image.from_color(size=(10, 10), color='white', duration=4.0)
-    scene = mv.fade_in(img, fade_in=1.0)
+    scene = mv.fade_in(img, duration=1.0)
 
     assert np.all(scene(0.0)[0, 0, :] == np.array([0, 0, 0, 0]))
     assert np.all(scene(1.0)[0, 0, :] == np.array([255, 255, 255, 255]))
@@ -151,7 +151,7 @@ def test_fade_in():
 
 def test_fade_out():
     img = mv.layer.Image.from_color(size=(10, 10), color='white', duration=4.0)
-    scene = mv.fade_out(img, fade_out=1.0)
+    scene = mv.fade_out(img, duration=1.0)
 
     assert np.all(scene(0.0)[0, 0, :] == np.array([255, 255, 255, 255]))
     assert np.all(scene(3.0)[0, 0, :] == np.array([255, 255, 255, 255]))


### PR DESCRIPTION
This PR implements `mv.fade_in, mv.fade_out, and mv.fade_in_out`

## Usage

```python
img = mv.layer.Image.from_color(size=(10, 10), color='white', duration=4.0)
scene1 = mv.fade_in(img, duration=1.0)  # fade-in effect
scene2 = mv.fade_out(img, duration=1.0)  # fade-out effect
scene3 = mv.fade_in_out(img, fade_in=1.0, fade_out=2.0)  # fade-in and fade-out effects
```