### PR TITLE
Fix bug clipping non-white text image

### DIFF
--- a/movis/layer/drawing.py
+++ b/movis/layer/drawing.py
@@ -595,7 +595,8 @@ class Text(AttributesMixin):
 def _clip_image(image: np.ndarray) -> np.ndarray:
     assert image.ndim == 3
     assert image.shape[2] == 4
-    non_empty_pixels = (image[:, :, 3] != 0)
+    alpha_is_zeros = np.isclose(image[:, :, 3], 0)
+    non_empty_pixels = np.logical_not(alpha_is_zeros)
     non_empty_row_indices, non_empty_col_indices = np.where(non_empty_pixels)
     if non_empty_row_indices.size == 0 or non_empty_col_indices.size == 0:
         return image


### PR DESCRIPTION
For non-white colors, QT creates a text image with only alpha equal to 0, thus, the clipping algorithm cannot remove empty pixels which results in misaligned text

**Before**
![image](https://github.com/rezoo/movis/assets/1390402/5074d167-06d8-49ef-88b2-df15e51803ec)
**After**
![image](https://github.com/rezoo/movis/assets/1390402/6103f86d-a2cb-4435-a403-00e08608c23f)
